### PR TITLE
preventMissilesInOwnBase

### DIFF
--- a/missilewars/src/main/java/de/linux4/missilewars/Config.java
+++ b/missilewars/src/main/java/de/linux4/missilewars/Config.java
@@ -28,6 +28,7 @@ public class Config {
 	private int itemCap;
 	private int resupplyTimer;
 	private boolean animatedExplosions;
+	private boolean preventMissilesInOwnBase;
 
 	public Config(File file) {
 		FileConfiguration conf = YamlConfiguration.loadConfiguration(file);
@@ -36,6 +37,7 @@ public class Config {
 		itemCap = conf.getInt("item-cap", 1);
 		resupplyTimer = conf.getInt("resupply-timer", 11);
 		animatedExplosions = conf.getBoolean("animated-explosions",true);
+		preventMissilesInOwnBase = conf.getBoolean("prevent-missiles-in-own-base",false);
 		if (maxPlayers % 2 != 0 || maxPlayers <= 0) {
 			throw new IllegalArgumentException("max-players should be an even number > 0");
 		}
@@ -66,4 +68,6 @@ public class Config {
 	}
 
 	public boolean animatedExplosions() {return animatedExplosions;}
+
+	public boolean preventMissilesInOwnBase() {return preventMissilesInOwnBase;}
 }

--- a/missilewars/src/main/java/de/linux4/missilewars/game/MissileCommands.java
+++ b/missilewars/src/main/java/de/linux4/missilewars/game/MissileCommands.java
@@ -27,11 +27,14 @@ import de.linux4.missilewars.MissileWars;
 
 import java.util.*;
 
+import static de.linux4.missilewars.game.Game.PlayerTeam.GREEN;
+import static de.linux4.missilewars.game.Game.PlayerTeam.RED;
+
 public class MissileCommands {
 
 	private CommandSender console = Bukkit.getConsoleSender();
 
-	public static void spawnObject(Game.PlayerTeam team,String objectName, Location location) {
+	public static boolean spawnObject(Game.PlayerTeam team,String objectName, Location location,int maxDistance) {
 		List position=positions.get(objectName);
 		String teamName;
 		switch (team) {
@@ -43,8 +46,10 @@ public class MissileCommands {
 				teamName="red";
 				break;
 			default:
-				return;
+				return false;
 		}
+		if(location.getZ()>maxDistance && team==GREEN && MissileWars.getMWConfig().preventMissilesInOwnBase()) return false;
+		if(location.getZ()<-maxDistance && team==RED && MissileWars.getMWConfig().preventMissilesInOwnBase()) return false;
 		Location rel = new Location(
 				location.getWorld(),
 				location.getX() + (Integer) position.get(0),
@@ -52,9 +57,10 @@ public class MissileCommands {
 				location.getZ() + (Integer) position.get(2)
 		);
 		MissileWars.getWorldEditUtil().pasteSchematic(teamName+"_"+objectName, rel, true);
+		return true;
 	}
-	public static void spawnObject(Game.PlayerTeam team, String objectName, World world) {
-		spawnObject(team,objectName,new Location(world,0,0,0));
+	public static boolean spawnObject(Game.PlayerTeam team, String objectName, World world) {
+		return spawnObject(team,objectName,new Location(world,0,0,0),100);
 	}
 	public static Map<String, List<Integer>> positions=new HashMap<>();
 	static {

--- a/missilewars/src/main/java/de/linux4/missilewars/game/SpawnItems.java
+++ b/missilewars/src/main/java/de/linux4/missilewars/game/SpawnItems.java
@@ -68,7 +68,7 @@ public class SpawnItems {
 		shield.setCustomNameVisible(false);
 		Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
 			public void run() {
-				if (shield != null) MissileCommands.spawnObject(game.getPlayerTeam(player),"shield",shield.getLocation());
+				if (shield != null) MissileCommands.spawnObject(game.getPlayerTeam(player),"shield",shield.getLocation(),70);
 			}
 		}, 20L);
 	}

--- a/missilewars/src/main/java/de/linux4/missilewars/listener/EventListener.java
+++ b/missilewars/src/main/java/de/linux4/missilewars/listener/EventListener.java
@@ -118,9 +118,8 @@ public class EventListener implements Listener {
 				}
 				String strippedName=name.toLowerCase().substring(2);
 				if(MissileCommands.positions.containsKey(strippedName)) {
-					MissileCommands.spawnObject(game.getPlayerTeam(p),strippedName,l);
-					SpawnItems.removeFromInv(p);
 					event.setCancelled(true);
+					if(MissileCommands.spawnObject(game.getPlayerTeam(p),strippedName,l,55)) SpawnItems.removeFromInv(p);
 				}
 			}
 			if (fireball.getItemMeta().getDisplayName().equalsIgnoreCase(name)) {

--- a/missilewars/src/main/resources/config.yml
+++ b/missilewars/src/main/resources/config.yml
@@ -24,4 +24,6 @@ item-cap: 1
 # Resupply timer in seconds (should be > 0)
 resupply-timer: 11
 # animated explosions toggle, causes a lot of lag.
-animated-explosions: true
+animated-explosions: false
+# prevents teamgreef, but also blocks spawning missiles when base is getting small. needs fixing.
+prevent-missiles-in-own-base: false


### PR DESCRIPTION
partly fixes #15, but stops spawning of missiles when base is small.